### PR TITLE
Ensure scripts dir exists

### DIFF
--- a/git-updater/tasks/main.yml
+++ b/git-updater/tasks/main.yml
@@ -1,4 +1,10 @@
 ---
+- name: Create scripts directory
+  file:
+    path: "{{ SCRIPTS_DIR }}"
+    owner: "{{ USERNAME }}"
+    group: "{{ USERNAME }}"
+    state: directory
 - name: Ensure git_update scripts are in place
   template:
     dest: "{{ SCRIPTS_DIR }}/git_updater.sh"


### PR DESCRIPTION
Running this on a clean system for federated properties gave me the following error:
```
TASK [git_updater : Ensure git_update scripts are in place] ********************************************************************************
fatal: [wikibase-federated-properties.vm]: FAILED! => {"changed": false, "checksum": "64dcbd10a4dbe4de0b0072b03ccf15c9a827f3b8", "msg": "Destination directory /opt/federatedProperties/scripts does not exist"}
```

Ensuring the `SCRIPTS_DIR` exists fixes it.